### PR TITLE
Center icons with text

### DIFF
--- a/components/IconBase.svelte
+++ b/components/IconBase.svelte
@@ -8,10 +8,11 @@
     stroke: currentColor;
     fill: currentColor;
     stroke-width: 0;
-    width: 100%;
+    width: 1em;
     height: auto;
-    max-height: 100%;
-  }  
+    max-height: 1em;
+    vertical-align: -0.15em;
+  } 
 </style>
 
 <svg xmlns="http://www.w3.org/2000/svg" {viewBox}>


### PR DESCRIPTION
This commit vertically aligns the icons with the text, and sets the icons width and height to 1em so that it can be used this way:

```html
<p>
  <SomeIcon /> Some text
</p>
```